### PR TITLE
make command optional on container creation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -62,7 +62,9 @@ public class CreateContainerCommand extends DockerCommand {
         
         DockerClient client = getClient();
         CreateContainerCmd cfgCmd = client.createContainerCmd(imageRes);
-        cfgCmd.withCmd(new String[] { commandRes });
+        if (!commandRes.isEmpty()) {
+            cfgCmd.withCmd(new String[] { commandRes });
+        }
         cfgCmd.withHostName(hostNameRes);
         ContainerCreateResponse resp = client.execute(cfgCmd);
         console.logInfo("created container id " + resp.getId() + " (from image " + imageRes + ")");


### PR DESCRIPTION
The _command_ parameter of `CreateContainerCommand` is always applied to the container, whether it is set or not.

This causes two problems when subsequently starting the container:
- if you leave the _command_ parameter empty, startup fails with 
  _Cannot start container [...]: exec: "": executable file not found in $PATH_
- if you specify a _command_, the container executes it instead of the one from the images's `CMD` setting.

Therefore you cannot use preconfigured startup commands in images.

With this PR, the _command_ parameter is only applied when it is specified.
