### PR TITLE
Exporting port bindings fails if EnvInvisibleAction does not contain Port bindings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerEnvContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerEnvContributor.java
@@ -48,7 +48,9 @@ public class DockerEnvContributor extends EnvironmentContributor {
         for (EnvInvisibleAction action : envActions) {
             containerIds = containerIds.concat(action.getId()).concat(ID_SEPARATOR);
             envs.put(CONTAINER_IP_PREFIX + action.getHostName(), action.getIpAddress());
-            exportPortBindings(envs, action.getPortBindings());
+            if (action.hasPortBindings()) {
+                exportPortBindings(envs, action.getPortBindings());
+            }
         }
 
         containerIds = containerIds.substring(0, containerIds.length() - 1);

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/action/EnvInvisibleAction.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/action/EnvInvisibleAction.java
@@ -51,6 +51,10 @@ public class EnvInvisibleAction extends InvisibleAction {
         return containerInfo.getNetworkSettings().getIpAddress();
     }
     
+    public boolean hasPortBindings() {
+        return containerInfo.getNetworkSettings().getPorts() != null;
+    }
+    
     public Map<ExposedPort, Binding> getPortBindings() {
         return containerInfo.getNetworkSettings().getPorts().getBindings();
     }


### PR DESCRIPTION
bd510236b553a6158d16babfb83d4913e5637f46 broke variable resolution for DOCKER_CONTAINER_IDS:
Create a Job with steps
- _Create container_
- _Start container_ using $DOCKER_CONTAINER_IDS
  The build will fail with 

> Failed to execute Docker command Start container(s): No such container $DOCKER_CONTAINER_IDS

Reason: The first step creates an action without port bindings. The second step then fails silently with an NPE when creating the port binding environment variables. The code to add DOCKER_CONTAINER_IDS is not executed.
