### PR TITLE
Use docker-java 0.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </scm>
 
 	<properties>
-		<version.docker.java>0.10.3-SNAPSHOT</version.docker.java>
+		<version.docker.java>0.10.3</version.docker.java>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
... so that we can get rid of the snapshot dependency.
