### PR TITLE
Use docker-java 0.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </scm>
 
     <properties>
-        <version.docker.java>0.10.4-SNAPSHOT</version.docker.java>
+        <version.docker.java>0.10.4</version.docker.java>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
... so that the build no longer fails because of unavailable snapshot dependencies.
