### PR TITLE
CPU shares and memory limit options for creating a container

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
@@ -1,16 +1,21 @@
 package org.jenkinsci.plugins.dockerbuildstep.util;
 
-import com.github.dockerjava.api.DockerException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import com.github.dockerjava.api.DockerException;
 
 /**
  * Util class to for docker commands.
@@ -59,5 +64,25 @@ public class CommandUtils {
             return fullImageName;
         }
         return fullImageName + ":latest";
+    }
+    
+    public static long sizeInBytes(String size) {
+        long returnValue = -1;
+        Pattern patt = Pattern.compile("^([\\d.]+)([gmkb]?)$", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = patt.matcher(size);
+        Map<String, Integer> powerMap = new HashMap<String, Integer>();
+        powerMap.put("g", 3);
+        powerMap.put("m", 2);
+        powerMap.put("k", 1);
+        powerMap.put("b", 0);
+        if (matcher.find()) {
+          String number = matcher.group(1);
+          int pow = matcher.group(2) != null && matcher.group(2).length() > 0 ?
+        		  powerMap.get(matcher.group(2).toLowerCase()) : 0;
+          BigDecimal bytes = new BigDecimal(number);
+          bytes = bytes.multiply(BigDecimal.valueOf(1024).pow(pow));
+          returnValue = bytes.longValue();
+        }
+        return returnValue;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand/config-detail.jelly
@@ -23,8 +23,11 @@
 		<f:entry field="exposedPorts" title="Exposed ports" description="Comma separated list of ports to be exposed. Example: 9000/tcp">
 			<f:textbox />
 		</f:entry>
+		<f:entry field="cpuShares" title="CPU shares" description="CPU shares (relative weight)">
+			<f:textbox />
+		</f:entry>
+		<f:entry field="memoryLimit" title="Memory limit" description="Memory limit (format: number{optional unit}, where unit = b, k, m or g). Example: 1024m">
+			<f:textbox />
+		</f:entry>		
 	</f:advanced>
-	
-	
-    
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtilsTest.java
@@ -41,4 +41,18 @@ public class CommandUtilsTest {
             assertEquals(output[i], CommandUtils.addLatestTagIfNeeded(input[i]));
         }
     }
+    
+    @Test
+    public void testSizeInBytes() {
+    	String[] input = {
+    			"64", "128b", "256k", "512m", "1g", "666a", "-9mb" 
+    	};
+    	long[] output = {
+    			64, 128, 262144, 536870912, 1073741824, -1, -1
+    	};
+        assertEquals("input length and output length differ!", input.length, output.length);
+        for (int i = 0; i < input.length; i++ ) {
+            assertEquals(output[i], CommandUtils.sizeInBytes(input[i]));
+        }
+    }
 }


### PR DESCRIPTION
Added support for creating containers with CPU shares (relative weight) and memory limit options. These options are useful for scheduling containers on a cluster.