### PR TITLE
Post build step to stop and remove Docker containers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.plugins.dockerbuildstep;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jenkinsci.plugins.dockerbuildstep.cmd.RemoveCommand;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.StopCommand;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.github.dockerjava.api.NotFoundException;
+import com.github.dockerjava.api.NotModifiedException;
+
+/**
+ * Post build step which stops and removes the Docker container. Use to cleanup container(s) in case of
+ * a build failure.
+ *
+ */
+@Extension
+public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
+
+	public DockerPostBuilder() {
+		super(DockerPostBuildStep.class);
+	}
+	
+	@Override
+	public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
+		return FreeStyleProject.class.equals(jobType);
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "Stop and remove Docker container";
+	}
+	
+	public static class DockerPostBuildStep extends Recorder {
+
+	    private final String containerIds;
+
+	    @DataBoundConstructor
+	    public DockerPostBuildStep(String containerIds) {
+	        this.containerIds = containerIds;
+	    }
+	
+		public BuildStepMonitor getRequiredMonitorService() {
+			return BuildStepMonitor.NONE;
+		}
+
+		public String getContainerIds() {
+			return containerIds;
+		}
+
+		@Override
+		public boolean perform(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher,
+				BuildListener listener) throws InterruptedException, IOException {
+			ConsoleLogger clog = new ConsoleLogger(listener);
+
+			List<String> ids = Arrays.asList(containerIds.split(","));
+			for (String id : ids) {
+				StopCommand stopCommand = new StopCommand(id);
+				try {
+					stopCommand.execute(build, clog);
+				}
+				catch (NotFoundException e) {
+					clog.logWarn("unable to stop container id " + id + ", container not found!");
+				}
+				catch (NotModifiedException e) {
+					// ignore, container already stopped
+				}
+			}			
+			
+			RemoveCommand removeCommand = new RemoveCommand(containerIds, true);
+			removeCommand.execute(build, clog);
+			
+			return true;
+		}
+	}
+}

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+    xmlns:f="/lib/form">
+
+    <f:entry field="containerIds" title="Container ID(s)" description="Comma separated list of containers to be stopped and removed.">
+        <f:textbox />
+    </f:entry>
+
+</j:jelly>


### PR DESCRIPTION
A failing build step stops the execution of the rest of the build steps, including a Docker stop/remove build step. Hence cleaning up (stopping and removing) Docker containers in a post build step is needed to keep the Docker host 'healthy'.