### PR TITLE
Add environment variable substitution to all commit command parameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
@@ -60,9 +60,13 @@ public class CommitCommand extends DockerCommand {
         }
 
         String containerIdRes = Resolver.buildVar(build, containerId);
+        String repoRes = Resolver.buildVar(build, repo);
+        String tagRes = Resolver.buildVar(build, tag);
+        String runCmdRes = Resolver.buildVar(build, runCmd);
 
         DockerClient client = getClient(null);
-        CommitCmd  commitCmd = client.commitCmd(containerIdRes).withRepository(repo).withTag(tag).withCmd(runCmd);
+        CommitCmd commitCmd =
+                client.commitCmd(containerIdRes).withRepository(repoRes).withTag(tagRes).withCmd(runCmdRes);
         String imageId = commitCmd.exec();
 
         console.logInfo("Container " + containerIdRes + " commited as image " + imageId);


### PR DESCRIPTION
I noticed that most other parameters will substitute environment variables like $BUILD_TAG, but the commit command only did it for the containers ids.
I wanted to be able to commit a container with a unique tag so that it could be inspected later.