### PR TITLE
Introduce a new exec command that combines create and start exec

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.dockerbuildstep.cmd;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+
+public class ExecCreateAndStartCommand extends DockerCommand {
+
+	private final String containerIds;
+	private final String command;
+	// TODO advanced config - IO streams
+
+	@DataBoundConstructor
+	public ExecCreateAndStartCommand(String containerIds, String command) {
+		this.containerIds = containerIds;
+		this.command = command;
+	}
+
+	public String getContainerIds() {
+		return containerIds;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	@Override
+	public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+			throws DockerException {
+		if (containerIds == null || containerIds.isEmpty()) {
+			console.logError("Container ID cannot be empty");
+			throw new IllegalArgumentException("Container ID cannot be empty");
+		}
+		if (command == null || command.isEmpty()) {
+			console.logError("Command cannot be empty");
+			throw new IllegalArgumentException("Command cannot be empty");
+		}
+
+		String containerIdsRes = Resolver.buildVar(build, containerIds);
+		String commandRes = Resolver.buildVar(build, command);
+
+		List<String> ids = Arrays.asList(containerIdsRes.split(","));
+		DockerClient client = getClient(null);
+		for (String id : ids) {
+			id = id.trim();
+			ExecCreateCmdResponse res = client.execCreateCmd(id).withCmd(commandRes.split(" ")).exec();
+			console.logInfo(String.format("Exec command with ID '%s' created in container '%s' ", res.getId(), id));
+			client.execStartCmd(res.getId()).exec();
+			console.logInfo(String.format("Executing command with ID '%s'", res.getId()));
+			res.getId();
+		}
+
+	}
+
+	@Extension
+	public static class ExecCreateAndStartCommandDescriptor extends DockerCommandDescriptor {
+		@Override
+		public String getDisplayName() {
+			return "Create and start exec instance in container(s)";
+		}
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand.java
@@ -3,10 +3,12 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.jenkinsci.plugins.dockerbuildstep.util.CommandUtils;
 import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -41,9 +43,10 @@ public class ExecStartCommand extends DockerCommand {
 
 		// TODO execute async on containers
 		for (String cmdId : cmdIds) {
-			client.execStartCmd(cmdId).exec();
 			console.logInfo(String.format("Executing command with ID '%s'", cmdId));
-			// TODO show output?
+			InputStream inputStream = client.execStartCmd(cmdId).exec();
+			CommandUtils.logCommandResultStream(inputStream, console,
+				"Failed to parse docker response when exec start");
 		}
 
 	}

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
@@ -57,6 +57,22 @@ public class CommandUtils {
         }
     }
 
+    /**
+     * Log a streamed response that is not wrapped in JSON
+     */
+    public static void logCommandResultStream(InputStream inputStream,
+            ConsoleLogger console, String errMessage) {
+        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+        String line = null;
+        try {
+          while((line = in.readLine()) != null) {
+            console.logInfo(line);
+          }
+        } catch (IOException e) {
+          throw new DockerException(line == null ? errMessage : line, 200, e);
+        }
+    }
+
     public static String addLatestTagIfNeeded(String fullImageName) {
         // Assuming that the fullImageName is a valid name, the pattern is
         // enough to decide if it contains tag or not.

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand/config-detail.jelly
@@ -1,0 +1,12 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+    xmlns:f="/lib/form">
+
+    <f:entry field="containerIds" title="Container ID(s)" description="Comma separated list of containers where the exec should be run.">
+        <f:textbox />
+    </f:entry>
+    
+    <f:entry field="command" title="Exec command" description="Command to be executed in the container(s)">
+        <f:textbox />
+    </f:entry>
+
+</j:jelly>


### PR DESCRIPTION
I wanted to make use of existing exec steps, but with the create and start steps separate I couldn't see how to pass the exec id from the create to the start steps. I considered exposing the ids as variables, but instead decided combine the steps. Is there ever a scenario where you would want to run them seperate?
I have left the existing steps for backwards compatibility, although I'm not sure that anyone can use them in their current form. I'm happy to get rid of them if required.
I have also added the ability to log the the streamed response from the Docker API as I wanted to have visibility of this. It would be better if this was configurable, but that can be done later if it is required.