### PR TITLE
upgraded docker commons dependency to 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <version.apache.httpclient>4.3.6</version.apache.httpclient>
         <version.docker.java>1.1.0</version.docker.java>
-        <version.jenkins.docker-commons>1.0</version.jenkins.docker-commons>
+        <version.jenkins.docker-commons>1.2</version.jenkins.docker-commons>
         <version.glassfish.javax.json>1.0.4</version.glassfish.javax.json>
         <version.jenkins.credentials>1.22</version.jenkins.credentials>
         <version.maven.release>2.5</version.maven.release>


### PR DESCRIPTION
Hey folks,

The latest Docker remote api is throwing an out of date client error when using the plugin.  Upgrading the docker-commons dependency resolves this.