### PR TITLE
Clarify the build step display text

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -150,7 +150,7 @@ public class DockerBuilder extends Builder {
 		}
 
 		public String getDisplayName() {
-			return "Execute Docker container";
+			return "Execute Docker command";
 		}
 
 		@Override


### PR DESCRIPTION
The build step display text is currently "Execute Docker container", and that is from back when the plugin did not do as much.  It is a confusing selection when you also have other docker plugins installed.  
