### PR TITLE
'Force' option added to commands for container removal

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
@@ -48,11 +48,13 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
 
         private final String containerIds;
         private final boolean removeVolumes;
+        private final boolean force;
 
         @DataBoundConstructor
-        public DockerPostBuildStep(String containerIds, boolean removeVolumes) {
+        public DockerPostBuildStep(String containerIds, boolean removeVolumes, boolean force) {
             this.containerIds = containerIds;
             this.removeVolumes = removeVolumes;
+            this.force = force;
         }
 
         public BuildStepMonitor getRequiredMonitorService() {
@@ -61,6 +63,10 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
 
         public String getContainerIds() {
             return containerIds;
+        }
+
+        public boolean isForce() {
+            return force;
         }
 
         @Override
@@ -80,7 +86,7 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
                 }
             }
 
-            RemoveCommand removeCommand = new RemoveCommand(containerIds, true, removeVolumes);
+            RemoveCommand removeCommand = new RemoveCommand(containerIds, true, removeVolumes, force);
             removeCommand.execute(build, clog);
 
             return true;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
@@ -65,6 +65,10 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
             return containerIds;
         }
 
+        public boolean isRemoveVolumes() {
+            return removeVolumes;
+        }
+
         public boolean isForce() {
             return force;
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
@@ -29,6 +29,10 @@ public class RemoveAllCommand extends DockerCommand {
         this.force = force;
     }
 
+    public boolean isRemoveVolumes() {
+        return removeVolumes;
+    }
+
     public boolean isForce() {
         return force;
     }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
@@ -21,20 +21,25 @@ import com.github.dockerjava.api.model.Container;
 public class RemoveAllCommand extends DockerCommand {
 
     private final boolean removeVolumes;
+    private final boolean force;
 
     @DataBoundConstructor
-    public RemoveAllCommand(boolean removeVolumes) {
+    public RemoveAllCommand(boolean removeVolumes, boolean force) {
         this.removeVolumes = removeVolumes;
+        this.force = force;
     }
 
-    @Override
+    public boolean isForce() {
+        return force;
+    }
+
+	@Override
     public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         DockerClient client = getClient(build, null);
         List<Container> containers = client.listContainersCmd().withShowAll(true).exec();
         for (Container container : containers) {
-            client.killContainerCmd(container.getId()).exec();
-            client.removeContainerCmd((container.getId())).withRemoveVolumes(removeVolumes).exec();
+            client.removeContainerCmd((container.getId())).withForce(force).withRemoveVolumes(removeVolumes).exec();
             console.logInfo("removed container id " + container.getId());
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
@@ -45,10 +45,10 @@ public class RemoveCommand extends DockerCommand {
         return ignoreIfNotFound;
     }
 
-    public boolean getRemoveVolumes() {
+    public boolean isRemoveVolumes() {
         return removeVolumes;
     }
-    
+
     public boolean isForce() {
         return force;
     }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
@@ -27,12 +27,14 @@ public class RemoveCommand extends DockerCommand {
     private final String containerIds;
     private final boolean ignoreIfNotFound;
     private final boolean removeVolumes;
+    private final boolean force;
 
     @DataBoundConstructor
-    public RemoveCommand(String containerIds, boolean ignoreIfNotFound, boolean removeVolumes) {
+    public RemoveCommand(String containerIds, boolean ignoreIfNotFound, boolean removeVolumes, boolean force) {
         this.containerIds = containerIds;
         this.ignoreIfNotFound = ignoreIfNotFound;
         this.removeVolumes = removeVolumes;
+        this.force = force;
     }
 
     public String getContainerIds() {
@@ -45,6 +47,10 @@ public class RemoveCommand extends DockerCommand {
 
     public boolean getRemoveVolumes() {
         return removeVolumes;
+    }
+    
+    public boolean isForce() {
+        return force;
     }
 
     @Override
@@ -62,8 +68,7 @@ public class RemoveCommand extends DockerCommand {
         for (String id : ids) {
             id = id.trim();
             try {
-                client.killContainerCmd(id).exec();
-                client.removeContainerCmd(id).withRemoveVolumes(removeVolumes).exec();
+                client.removeContainerCmd(id).withForce(force).withRemoveVolumes(removeVolumes).exec();
                 console.logInfo("removed container id " + id);
             } catch (NotFoundException e) {
                 if (!ignoreIfNotFound) {

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
@@ -9,6 +9,10 @@
         <f:entry field="removeVolumes" title="Remove volumes" description="Remove the volumes associated with the container." >
             <f:checkbox />
         </f:entry>
+        
+        <f:entry field="force" title="Force remove" description="Force the removal of a running container (uses SIGKILL)." >
+            <f:checkbox />
+        </f:entry>
     </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand/config-detail.jelly
@@ -9,5 +9,9 @@
         <f:entry field="removeVolumes" title="Remove volumes" description="Remove the volumes associated with the container." >
             <f:checkbox />
         </f:entry>
+        
+        <f:entry field="force" title="Force remove" description="Force the removal of a running container (uses SIGKILL)." >
+            <f:checkbox />
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
@@ -13,6 +13,10 @@
         <f:entry field="removeVolumes" title="Remove volumes" description="Remove the volumes associated with the container." >
             <f:checkbox />
         </f:entry>
+        
+        <f:entry field="force" title="Force remove" description="Force the removal of a running container (uses SIGKILL)." >
+            <f:checkbox />
+        </f:entry>
     </f:advanced>
 
 </j:jelly>


### PR DESCRIPTION
Hi,

1. Added 'force' option to RemoveCommand, RemoveAllCommand and DockerPostBuildStep. Remove in 'force' mode kills the container (if running) beforehand, so no need to call client.killContainerCmd before removal anymore. 

2. Added getters to 'removeVolumes' option, otherwise Jenkins won't display the current value of this option.