### PR TITLE
docker-build-step-plugin-55 dockerCertPath needs to be a property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -193,6 +193,10 @@ public class DockerBuilder extends Builder {
             return dockerVersion;
         }
 
+        public String getDockerCertPath() {
+            return dockerCertPath;
+        }
+
         public DockerClient getDockerClient(AuthConfig authConfig) {
             // Reason to return a new DockerClient each time this function is called:
             // - It is a legitimate scenario that different jobs or different build steps


### PR DESCRIPTION
dockerCertPath is not a property. Thus the field "cert file path" is not restored after restarts and will be empty in jenkins configure view.
[cert file path](https://www.screencast.com/t/OabtpjVC6OU)