### PR TITLE
Cover the case that buildArgs value is empty string.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
@@ -78,7 +78,7 @@ public class CreateImageCommand extends DockerCommand {
         }
         final Map<String, String> buildArgsMap = new HashMap<String, String>();
 
-        if (buildArgs != null) {
+        if ((buildArgs != null) && (buildArgs != "")) {
             console.logInfo("Parsing buildArgs: " + buildArgs);
             String[] split = Resolver.buildVar(build, buildArgs).split(",|;");
             for (String arg : split) {


### PR DESCRIPTION
When lefts Build arguments empty, the build process raise an error:
> [Docker] INFO: Parsing buildArgs: 
> [Docker] ERROR: Invalid format for . Buildargs should be formatted as key=value

when I fill something into the Build arguments form, like:
> foo=bar
 
the error disappeared.