### PR TITLE
Update config-detail.jelly: Document "Wait for ports" format

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand/config-detail.jelly
@@ -12,7 +12,7 @@ help file problem.
 -->
     <f:advanced align="left">
 
-        <f:entry field="waitPorts" title="Wait for ports">
+        <f:entry field="waitPorts" title="Wait for ports" description="List of container port combinations to wait for. Format [container] [port1],[port2]">
             <f:textarea />
         </f:entry>
 


### PR DESCRIPTION
Added rudimentary description about the required format to to use the "Wait for ports" feature in the start command.