### PR TITLE
Fix for JENKINS-24071: Docker build step tries to build on master and not slave

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
@@ -83,7 +83,7 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
             for (String id : ids) {
                 StopCommand stopCommand = new StopCommand(id);
                 try {
-                    stopCommand.execute(build, clog);
+                    stopCommand.execute(launcher, build, clog);
                 } catch (NotFoundException e) {
                     clog.logWarn("unable to stop container id " + id + ", container not found!");
                 } catch (NotModifiedException e) {
@@ -92,7 +92,7 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
             }
 
             RemoveCommand removeCommand = new RemoveCommand(containerIds, true, removeVolumes, force);
-            removeCommand.execute(build, clog);
+            removeCommand.execute(launcher, build, clog);
 
             return true;
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -52,7 +53,7 @@ public class CommitCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException, AbortException {
         // TODO check it when submitting the form
         if (containerId == null || containerId.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -7,6 +7,7 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.*;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.util.FormValidation;
 import org.jenkinsci.plugins.dockerbuildstep.action.EnvInvisibleAction;
@@ -136,7 +137,7 @@ public class CreateContainerCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         // TODO check it when submitting the form
         if (image == null || image.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd;
 import hudson.AbortException;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Launcher;
 import hudson.model.Describable;
 import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
@@ -17,6 +18,7 @@ import org.apache.commons.io.Charsets;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.DockerCredConfig;
 import org.jenkinsci.plugins.dockerbuildstep.action.DockerContainerConsoleAction;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -85,12 +87,22 @@ public abstract class DockerCommand implements Describable<DockerCommand>, Exten
     public static CredentialsMatcher CREDENTIALS_MATCHER = CredentialsMatchers.anyOf(CredentialsMatchers
             .instanceOf(StandardUsernamePasswordCredentials.class));
 
-    public abstract void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public abstract void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException, AbortException;
 
     protected static DockerClient getClient(AbstractBuild<?,?> build, AuthConfig authConfig) {
         return ((DockerBuilder.DescriptorImpl) Jenkins.getInstance().getDescriptor(DockerBuilder.class))
                 .getDockerClient(build, authConfig);
+    }
+
+    protected static DockerClient getClient(Descriptor<?> descriptor, String dockerUrlRes, String dockerVersionRes, String dockerCertPathRes, AuthConfig authConfig) {
+        return ((DockerBuilder.DescriptorImpl) descriptor)
+                .getDockerClient(dockerUrlRes, dockerVersionRes, dockerCertPathRes, authConfig);
+    }
+
+    protected static Config getConfig(AbstractBuild<?,?> build) {
+        return ((DockerBuilder.DescriptorImpl) Jenkins.getInstance().getDescriptor(DockerBuilder.class))
+                .getConfig(build);
     }
 
     public DockerCommandDescriptor getDescriptor() {
@@ -104,7 +116,7 @@ public abstract class DockerCommand implements Describable<DockerCommand>, Exten
     public String getInfoString() {
         return "Info from DockerCommand";
     }
-
+    
     /**
      * Only the first container started is attached!
      */

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
@@ -35,7 +36,7 @@ public class ExecCreateAndStartCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, final ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, final ConsoleLogger console)
             throws DockerException {
         if (containerIds == null || containerIds.isEmpty()) {
             console.logError("Container ID cannot be empty");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ public class ExecCreateCommand extends DockerCommand {
 	}
 
 	@Override
-	public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+	public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
 			throws DockerException {
 		if (containerIds == null || containerIds.isEmpty()) {
 			console.logError("Container ID cannot be empty");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
@@ -27,7 +28,7 @@ public class ExecStartCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, final ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, final ConsoleLogger console)
             throws DockerException {
 
         if (commandIds == null || commandIds.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ public class KillCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         if (containerIds == null || containerIds.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.core.command.PushImageResultCallback;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.io.InputStream;
@@ -57,7 +58,7 @@ public class PullImageCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build,final ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build,final ConsoleLogger console)
             throws DockerException, AbortException {
         // TODO check it when submitting the form
         if (fromImage == null || fromImage.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand.java
@@ -7,6 +7,7 @@ import com.github.dockerjava.api.model.PushResponseItem;
 import com.github.dockerjava.core.command.PushImageResultCallback;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
@@ -48,7 +49,7 @@ public class PushImageCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(AbstractBuild build, final ConsoleLogger console) throws DockerException,
+    public void execute(Launcher launcher, AbstractBuild build, final ConsoleLogger console) throws DockerException,
             AbortException {
         if (!StringUtils.isNotBlank(image)) {
             throw new IllegalArgumentException("Image name must be provided");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.List;
@@ -38,7 +39,7 @@ public class RemoveAllCommand extends DockerCommand {
     }
 
 	@Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         DockerClient client = getClient(build, null);
         List<Container> containers = client.listContainersCmd().withShowAll(true).exec();

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.Arrays;
@@ -54,7 +55,7 @@ public class RemoveCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         // TODO check it when submitting the form
         if (containerIds == null || containerIds.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -47,7 +48,7 @@ public class RemoveImageCommand extends DockerCommand {
 	}
 
 	@Override
-	public void execute(@SuppressWarnings("rawtypes") AbstractBuild build,
+	public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build,
 			ConsoleLogger console) throws DockerException {
 		// TODO check it when submitting the form
 		if (imageName == null || imageName.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public class RestartCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console) throws DockerException {
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console) throws DockerException {
         if (containerIds == null || containerIds.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.io.File;
@@ -67,7 +68,7 @@ public class SaveImageCommand extends DockerCommand {
 	}
 
 	@Override
-	public void execute(@SuppressWarnings("rawtypes") AbstractBuild build,
+	public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build,
 			ConsoleLogger console) throws DockerException {
 
 		if (imageName == null || imageName.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.List;
@@ -36,7 +37,7 @@ public class StartByImageIdCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         if (imageId == null || imageId.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.util.FormValidation;
 import org.jenkinsci.plugins.dockerbuildstep.action.DockerContainerConsoleAction;
@@ -51,7 +52,7 @@ public class StartCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         if (containerIds == null || containerIds.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopAllCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopAllCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.List;
@@ -25,7 +26,7 @@ public class StopAllCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         DockerClient client = getClient(build, null);
         List<Container> containers = client.listContainersCmd().exec();

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopByImageIdCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopByImageIdCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.List;
@@ -33,7 +34,7 @@ public class StopByImageIdCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         if (imageId == null || imageId.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ public class StopCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)
             throws DockerException {
         if (containerIds == null || containerIds.isEmpty()) {
             throw new IllegalArgumentException("At least one parameter is required");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import hudson.Extension;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
@@ -54,7 +55,7 @@ public class TagImageCommand extends DockerCommand {
     }
 
     @Override
-    public void execute(@SuppressWarnings("rawtypes") AbstractBuild build,
+    public void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build,
                         ConsoleLogger console) throws DockerException {
         // TODO check it when submitting the form
         if (image == null || image.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/Resolver.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/Resolver.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  */
 public class Resolver {
 
-    public static String buildVar(final AbstractBuild<?, ?> build,final String toResolve) {
+    public static String buildVar(final AbstractBuild<?, ?> build, final String toResolve) {
         if(toResolve == null)
             return null;
         


### PR DESCRIPTION
Currently, the plugin can't cope well with Jenkins Slaves as it's described in [this issue](https://issues.jenkins-ci.org/browse/JENKINS-24071).

This changeset contains modifications that provide basic infrastructure for the ```DockerCommands``` to perform their task on slave nodes as well:
- the ```Launcher``` is provided for executions, as it's needed to get a ```Channel```.
- the ```DockerBuilder``` and related core functionality got augmented to provide serializable configuration required for the docker commands.

The changeset also contains modifications for the ```CreateImageCommand``` to take advantage of this and be able to work on slaves. Currently, this is the only one I've changed in an attempt to get earlier feedback if this solution is acceptable - and because for us, the this is the only command we can't execute on the master node. Now we use this command in our jobs without any problems in our slaves.

Please review this approach, and if you find it OK, I'll update the rest of the commands to work on the slaves as well.