### PR TITLE
Align with Jenkins 1.579 to include fix for [JENKINS-21977]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.554.1</version>
+        <version>1.579</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -61,6 +61,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
             <version>${version.jenkins.docker-commons}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>${version.matrix-project}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
As discussed in https://issues.jenkins-ci.org/browse/JENKINS-21977, the Jenkins parent plugin dependency needs to be updated in order to solve the "secret.key" test error. Version `1.579` seems indeed to be the smallest version working.
As side effect the explicit declaration of the `matrix-project` dependency was needed, since it isn't provided by the parent project anymore.