### PR TITLE
Updates to docker-java 3.1.0-rc-7, docker-commons 1.11 and plugin 3.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,17 @@
     </pluginRepositories>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jenkins-ci.tools</groupId>
+                    <artifactId>maven-hpi-plugin</artifactId>
+                    <configuration>
+                        <disabledTestInjection>true</disabledTestInjection>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.579</version>
+        <version>3.31</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -27,14 +28,40 @@
     </scm>
 
     <properties>
-        <version.apache.httpclient>4.5.2</version.apache.httpclient>
-        <version.docker.java>3.0.10</version.docker.java>
-        <version.jenkins.docker-commons>1.4.0</version.jenkins.docker-commons>
+        <version.apache.httpclient>4.5.6</version.apache.httpclient>
+        <version.docker.java>3.1.0-rc-7</version.docker.java>
+        <version.jenkins.docker-commons>1.11</version.jenkins.docker-commons>
         <version.glassfish.javax.json>1.0.4</version.glassfish.javax.json>
-        <version.jenkins.credentials>1.22</version.jenkins.credentials>
-        <version.maven.release>2.5</version.maven.release>
-        <version.matrix-project>1.4.1</version.matrix-project>
+        <version.jenkins.credentials>2.1.13</version.jenkins.credentials>
+        <version.maven.release>2.5.3</version.maven.release>
+        <version.matrix-project>1.13</version.matrix-project>
+        <java.level>8</java.level>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.21</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.21</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.10</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.11</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency> <!-- Overwrites transitive dependency, otherwise fails with java.lang.ClassNotFoundException: org.apache.http.config.Lookup -->
@@ -101,7 +128,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
                     <failOnError>false</failOnError>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <configuration>
+                        <onlyAnalyze>none.*</onlyAnalyze>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                     <configuration>

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
@@ -1,33 +1,28 @@
 package org.jenkinsci.plugins.dockerbuildstep;
 
-import com.google.common.base.Strings;
-
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.github.dockerjava.api.model.AuthConfig;
-
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.security.ACL;
+import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
-import hudson.model.Descriptor;
-import hudson.security.ACL;
-import hudson.model.Item;
-import hudson.util.ListBoxModel;
-import hudson.Extension;
-
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import javax.annotation.Nullable;
-
-import hudson.model.AbstractDescribableImpl;
 
 /**
  * Credential configuration which allows docker commands to authenticate with registries.

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerEnvContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerEnvContributor.java
@@ -1,23 +1,17 @@
 package org.jenkinsci.plugins.dockerbuildstep;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.model.TaskListener;
-import hudson.model.EnvironmentContributor;
-import hudson.model.Run;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.jenkinsci.plugins.dockerbuildstep.action.EnvInvisibleAction;
-
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.google.common.base.Joiner;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.dockerbuildstep.action.EnvInvisibleAction;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * This contributor adds various Docker relate variable like container IDs or IP addresses into build environment
@@ -29,12 +23,12 @@ import com.google.common.base.Joiner;
 @Extension
 public class DockerEnvContributor extends EnvironmentContributor {
 
-	public final String ID_SEPARATOR = ",";
-	public final String CONTAINER_IDS_ENV_VAR = "DOCKER_CONTAINER_IDS";
-	public final String CONTAINER_IP_PREFIX = "DOCKER_IP_";
-	public final String PORT_BINDINGS_ENV_VAR = "DOCKER_HOST_BIND_PORTS";
-	public final String PORT_BINDING_PREFIX = "DOCKER_HOST_PORT_";
-	public final String HOST_SOCKET_PREFIX = "DOCKER_HOST_SOCKET_";
+	public final static String ID_SEPARATOR = ",";
+	public final static String CONTAINER_IDS_ENV_VAR = "DOCKER_CONTAINER_IDS";
+	public final static String CONTAINER_IP_PREFIX = "DOCKER_IP_";
+	public final static String PORT_BINDINGS_ENV_VAR = "DOCKER_HOST_BIND_PORTS";
+	public final static String PORT_BINDING_PREFIX = "DOCKER_HOST_PORT_";
+	public final static String HOST_SOCKET_PREFIX = "DOCKER_HOST_SOCKET_";
 
 	@Override
 	public void buildEnvironmentFor(@SuppressWarnings("rawtypes") Run r, EnvVars envs, TaskListener listener)
@@ -65,9 +59,10 @@ public class DockerEnvContributor extends EnvironmentContributor {
 
 	private void exportPortBindings(EnvVars envs, Map<ExposedPort, Binding[]> bindings) {
 		StringBuilder ports = new StringBuilder();
-		for (ExposedPort exposedPort : bindings.keySet()) {
+		for (Map.Entry<ExposedPort, Binding[]> entry : bindings.entrySet()) {
+			ExposedPort exposedPort = entry.getKey();
 			ports.append(exposedPort.toString()).append(ID_SEPARATOR);
-			Binding[] exposedPortBinding = bindings.get(exposedPort);
+			Binding[] exposedPortBinding = entry.getValue();
 			if (exposedPortBinding == null) {
 				continue;
 			}

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -221,7 +221,7 @@ public class CreateContainerCommand extends DockerCommand {
             EnvInvisibleAction envAction = new EnvInvisibleAction(inspectResp);
             build.addAction(envAction);
         } catch (Exception e) {
-            console.logError("failed to stop all containers");
+            console.logError("failed to create containers");
             e.printStackTrace();
             throw new IllegalArgumentException(e);
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
@@ -1,28 +1,5 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
-import hudson.AbortException;
-import hudson.DescriptorExtensionList;
-import hudson.ExtensionPoint;
-import hudson.Launcher;
-import hudson.model.Describable;
-import hudson.model.AbstractBuild;
-import hudson.model.Descriptor;
-import hudson.model.Job;
-
-import java.io.IOException;
-
-import jenkins.model.Jenkins;
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.Charsets;
-import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
-import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder;
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.DockerCredConfig;
-import org.jenkinsci.plugins.dockerbuildstep.action.DockerContainerConsoleAction;
-import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
-
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -30,6 +7,26 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.google.common.base.Strings;
+import hudson.AbortException;
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.Charsets;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.DockerCredConfig;
+import org.jenkinsci.plugins.dockerbuildstep.action.DockerContainerConsoleAction;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+
+import java.io.IOException;
 
 /**
  * Parent class of all Docker commands.
@@ -84,7 +81,7 @@ public abstract class DockerCommand implements Describable<DockerCommand>, Exten
         return authConfig;
     }
 
-    public static CredentialsMatcher CREDENTIALS_MATCHER = CredentialsMatchers.anyOf(CredentialsMatchers
+    public static final CredentialsMatcher CREDENTIALS_MATCHER = CredentialsMatchers.anyOf(CredentialsMatchers
             .instanceOf(StandardUsernamePasswordCredentials.class));
 
     public abstract void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CommitRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CommitRemoteCallable.java
@@ -1,16 +1,14 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CommitCmd;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the commit command.
@@ -45,5 +43,10 @@ public class CommitRemoteCallable implements Callable<String, Exception>, Serial
                 client.commitCmd(containerIdRes).withRepository(repoRes).withTag(tagRes).withCmd(runCmdRes);
         String imageId = commitCmd.exec();
         return imageId;
+    }
+
+    @Override
+    public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
@@ -1,21 +1,20 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.File;
-import java.io.Serializable;
-import java.util.Map;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.BuildResponseItem;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
-
 import hudson.FilePath;
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.Map;
 
 /**
  * A Callable wrapping the commands necessary to create an image.
@@ -97,5 +96,10 @@ public class CreateImageRemoteCallable implements Callable<String, Exception>, S
         } catch (Exception e) {
             throw new DockerException("Could not check file", 0, e);
         }
+    }
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecCreateRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecCreateRemoteCallable.java
@@ -1,16 +1,14 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the exec create command.
@@ -50,4 +48,8 @@ public class ExecCreateRemoteCallable implements Callable<String, Exception>, Se
         return response.getId();
     }
 
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecStartRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecStartRemoteCallable.java
@@ -1,19 +1,17 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
-
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the exec start command.
@@ -64,5 +62,9 @@ public class ExecStartRemoteCallable implements Callable<Void, Exception>, Seria
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/KillContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/KillContainerRemoteCallable.java
@@ -1,15 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the kill container command.
@@ -40,5 +38,9 @@ public class KillContainerRemoteCallable implements Callable<Void, Exception>, S
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ListContainersRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ListContainersRemoteCallable.java
@@ -1,17 +1,15 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-import java.util.List;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
+import java.util.List;
 
 /**
  * A Callable wrapping the list containers command.
@@ -40,5 +38,9 @@ public class ListContainersRemoteCallable implements Callable<List<Container>, E
         List<Container> containers = client.listContainersCmd().withShowAll(showAll).exec();
         return containers;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
@@ -1,21 +1,19 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.core.command.PullImageResultCallback;
-
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the pull command.
@@ -65,5 +63,9 @@ public class PullImageRemoteCallable implements Callable<Void, Exception>, Seria
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
@@ -1,21 +1,19 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PushImageCmd;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PushResponseItem;
 import com.github.dockerjava.core.command.PushImageResultCallback;
-
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the push command.
@@ -67,5 +65,9 @@ public class PushImageRemoteCallable implements Callable<Void, Exception>, Seria
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveContainerRemoteCallable.java
@@ -1,15 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the remove container command.
@@ -44,5 +42,9 @@ public class RemoveContainerRemoteCallable implements Callable<Void, Exception>,
                 
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveImageRemoteCallable.java
@@ -1,15 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the remove image command.
@@ -45,5 +43,9 @@ public class RemoveImageRemoteCallable implements Callable<Void, Exception>, Ser
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RestartContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RestartContainerRemoteCallable.java
@@ -1,15 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the restart container command.
@@ -45,5 +43,9 @@ public class RestartContainerRemoteCallable implements Callable<Void, Exception>
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/SaveImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/SaveImageRemoteCallable.java
@@ -1,19 +1,17 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
+import com.github.dockerjava.api.DockerClient;
+import hudson.model.Descriptor;
+import hudson.remoting.Callable;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-
-import org.apache.commons.io.IOUtils;
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
-import com.github.dockerjava.api.DockerClient;
-
-import hudson.model.Descriptor;
-import hudson.remoting.Callable;
-
 
 /**
  * A Callable wrapping the save image command.
@@ -62,5 +60,8 @@ public class SaveImageRemoteCallable implements Callable<Void, Exception>, Seria
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
@@ -1,17 +1,15 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the start container command.
@@ -44,5 +42,9 @@ public class StartContainerRemoteCallable implements Callable<String, Exception>
         String serialized = mapper.writeValueAsString(inspectResp);
         return serialized;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StopContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StopContainerRemoteCallable.java
@@ -1,15 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
 
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the stop container command.
@@ -40,5 +38,9 @@ public class StopContainerRemoteCallable implements Callable<Void, Exception>, S
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/TagImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/TagImageRemoteCallable.java
@@ -1,14 +1,13 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
-import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
-import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
-
 import com.github.dockerjava.api.DockerClient;
-
 import hudson.model.Descriptor;
 import hudson.remoting.Callable;
+import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
+import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.Serializable;
 
 /**
  * A Callable wrapping the tag image command.
@@ -44,5 +43,9 @@ public class TagImageRemoteCallable implements Callable<Void, Exception>, Serial
         
         return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/WaitForPortsRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/WaitForPortsRemoteCallable.java
@@ -1,21 +1,19 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
-
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.remoting.Callable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.jenkinsci.plugins.dockerbuildstep.util.PortUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-
-import hudson.model.BuildListener;
-import hudson.model.Descriptor;
-import hudson.remoting.Callable;
-
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A Callable wrapping the inspect container command.
@@ -65,5 +63,9 @@ public class WaitForPortsRemoteCallable implements Callable<Void, Exception>, Se
     	
     	return null;
     }
-    
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
@@ -1,21 +1,20 @@
 package org.jenkinsci.plugins.dockerbuildstep.util;
 
+import com.github.dockerjava.api.exception.DockerException;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import net.sf.json.JSONObject;
-
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
-
-import com.github.dockerjava.api.exception.DockerException;
 
 /**
  * Util class to for docker commands.
@@ -42,7 +41,7 @@ public class CommandUtils {
 
     public static void logCommandResult(InputStream inputStream,
             ConsoleLogger console, String errMessage) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         String line = null;
         try {
           while((line = in.readLine()) != null) {
@@ -62,7 +61,7 @@ public class CommandUtils {
      */
     public static void logCommandResultStream(InputStream inputStream,
             ConsoleLogger console, String errMessage) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         String line = null;
         try {
           while((line = in.readLine()) != null) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/PortUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/PortUtils.java
@@ -46,20 +46,19 @@ public class PortUtils {
         return false;
     }
 
-    public static Map<String, List<Integer>> parsePorts(String waitPorts) throws IllegalArgumentException,
-            NumberFormatException {
+    public static Map<String, List<Integer>> parsePorts(String waitPorts) throws IllegalArgumentException {
         Map<String, List<Integer>> containers = new HashMap<String, List<Integer>>();
         String[] containerPorts = waitPorts.split(System.getProperty("line.separator"));
         for (String container : containerPorts) {
             String[] idPorts = container.split(" ", 2);
             if (idPorts.length < 2)
-                throw new IllegalArgumentException("Cannot parse " + idPorts + " as '[conainerId] [port1],[port2],...'");
+                throw new IllegalArgumentException("Cannot parse " + container + " as '[conainerId] [port1],[port2],...'");
             String containerId = idPorts[0].trim();
             String portsStr = idPorts[1].trim();
 
             List<Integer> ports = new ArrayList<Integer>();
             for (String port : portsStr.split(",")) {
-                ports.add(new Integer(port));
+                ports.add(Integer.valueOf(port));
             }
             containers.put(containerId, ports);
         }


### PR DESCRIPTION
Solves the issue with the deserialization of com.github.dockerjava.api.command.InspectContainerResponse["Mounts"].