### PR TITLE
fix console logging of build/pull/push commands

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
@@ -106,7 +106,7 @@ public class CreateImageCommand extends DockerCommand {
             Config cfgData = getConfig(build);
             Descriptor<?> descriptor = Jenkins.getInstance().getDescriptor(DockerBuilder.class);
             
-            imageId = launcher.getChannel().call(new CreateImageRemoteCallable(cfgData, descriptor, expandedDockerFolder, expandedImageTag, dockerFileRes, buildArgsMap, noCache, rm));
+            imageId = launcher.getChannel().call(new CreateImageRemoteCallable(console.getListener(), cfgData, descriptor, expandedDockerFolder, expandedImageTag, dockerFileRes, buildArgsMap, noCache, rm));
         } catch (Exception e) {
             console.logError("Failed to create docker image: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
@@ -51,7 +51,10 @@ public class PullImageRemoteCallable implements Callable<Void, Exception>, Seria
         PullImageResultCallback callback = new PullImageResultCallback() {
             @Override
             public void onNext(PullResponseItem item) {
-                console.logInfo(item.toString());
+                String text = item.getStream();
+                if (text != null) {
+                    console.logInfo(text);
+                }
                 super.onNext(item);
             }
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
@@ -53,7 +53,10 @@ public class PushImageRemoteCallable implements Callable<Void, Exception>, Seria
         PushImageResultCallback callback = new PushImageResultCallback() {
             @Override
             public void onNext(PushResponseItem item) {
-                console.logInfo(item.toString());
+                String text = item.getStream();
+                if (text != null) {
+                    console.logInfo(text);
+                }
                 super.onNext(item);
             }
 


### PR DESCRIPTION
1. Create/build wasn't logging anything before
2. Logs for push used to look like:

```
[Docker] INFO: BuildResponseItem[stream=
,status=<null>,progressDetail=<null>,progress=<null>,id=<null>,from=<null>,time=<null>,errorDetail=<null>,error=<null>,aux=<null>]
[Docker] INFO: BuildResponseItem[stream= ---> d031200b6d71
,status=<null>,progressDetail=<null>,progress=<null>,id=<null>,from=<null>,time=<null>,errorDetail=<null>,error=<null>,aux=<null>]
```

Now they look like:

```
[Docker] INFO:  ---> Using cache

[Docker] INFO:  ---> 681d455e2526
```