### PR TITLE
Add option to force pull base image before build docker images

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
@@ -28,15 +28,17 @@ public class CreateImageCommand extends DockerCommand {
     private final String dockerFolder;
     private final String imageTag;
     private final String dockerFile;
+    private final boolean pull;
     private final boolean noCache;
     private final boolean rm;
     private final String buildArgs;
     
     @DataBoundConstructor
-    public CreateImageCommand(String dockerFolder, String imageTag, String dockerFile, boolean noCache, boolean rm, String buildArgs) {
+    public CreateImageCommand(String dockerFolder, String imageTag, String dockerFile, boolean pull, boolean noCache, boolean rm, String buildArgs) {
         this.dockerFolder = dockerFolder;
         this.imageTag = imageTag;
         this.dockerFile = dockerFile;
+        this.pull = pull;
         this.noCache = noCache;
         this.buildArgs = buildArgs;
         this.rm = rm;
@@ -52,6 +54,10 @@ public class CreateImageCommand extends DockerCommand {
 
     public String getDockerFile() {
         return dockerFile;
+    }
+
+    public boolean isPull() {
+        return pull;
     }
 
     public boolean isNoCache() {
@@ -105,8 +111,8 @@ public class CreateImageCommand extends DockerCommand {
         try {
             Config cfgData = getConfig(build);
             Descriptor<?> descriptor = Jenkins.getInstance().getDescriptor(DockerBuilder.class);
-            
-            imageId = launcher.getChannel().call(new CreateImageRemoteCallable(console.getListener(), cfgData, descriptor, expandedDockerFolder, expandedImageTag, dockerFileRes, buildArgsMap, noCache, rm));
+
+            imageId = launcher.getChannel().call(new CreateImageRemoteCallable(console.getListener(), cfgData, descriptor, expandedDockerFolder, expandedImageTag, dockerFileRes, buildArgsMap, pull, noCache, rm));
         } catch (Exception e) {
             console.logError("Failed to create docker image: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
@@ -39,15 +39,17 @@ public class CreateImageRemoteCallable implements Callable<String, Exception>, S
     String expandedImageTag;
     String dockerFileRes;
     Map<String, String> buildArgsMap;
+    boolean pull;
     boolean noCache;
     boolean rm;
-    public CreateImageRemoteCallable(BuildListener listener, Config cfgData, Descriptor<?> descriptor, String expandedDockerFolder, String expandedImageTag, String dockerFileRes, Map<String, String> buildArgsMap, boolean noCache, boolean rm) {
+    public CreateImageRemoteCallable(BuildListener listener, Config cfgData, Descriptor<?> descriptor, String expandedDockerFolder, String expandedImageTag, String dockerFileRes, Map<String, String> buildArgsMap, boolean pull, boolean noCache, boolean rm) {
         this.listener = listener;
         this.expandedDockerFolder = expandedDockerFolder;
         this.expandedImageTag = expandedImageTag;
         this.dockerFileRes = dockerFileRes;
         this.cfgData = cfgData;
         this.buildArgsMap = buildArgsMap;
+        this.pull = pull;
         this.noCache = noCache;
         this.rm = rm;
         this.descriptor = descriptor;
@@ -89,6 +91,7 @@ public class CreateImageRemoteCallable implements Callable<String, Exception>, S
         BuildImageCmd buildImageCmd = client
                 .buildImageCmd(docker)
                 .withTag(expandedImageTag)
+                .withPull(pull)
                 .withNoCache(noCache)
                 .withRemove(rm);
         if (!buildArgsMap.isEmpty()) {

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
@@ -13,6 +13,10 @@
             <f:textbox default="Dockerfile" />
         </f:entry>
 
+        <f:entry field="pull" title="Attempt to pull a newer version of the image">
+            <f:checkbox />
+        </f:entry>
+
         <f:entry field="noCache" title="Don't use the cache when building the image">
             <f:checkbox />
         </f:entry>


### PR DESCRIPTION
Added option to force pull base image before build docker image. 
It might be useful when user builds custom image based on image that may be updated in future, e.g. node:lts, python:3, jenkins:lts.