### PR TITLE
Update pom.xml to use GitHub URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>docker-build-step</artifactId>
     <version>2.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Docker+build+step+plugin</url>
+    <url>https://github.com/jenkinsci/docker-build-step-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Enable GitHub documentation for this plugin on plugins.jenkins.io
according to the blog post
https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/

This will migrate the plugin documentation to GitHub as the wiki
is currently set to read-only and the documentation on GitHub is
far more detailed anyway.