### PR TITLE
Fix parsing of build args with '='

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
@@ -89,7 +89,7 @@ public class CreateImageCommand extends DockerCommand {
             console.logInfo("Parsing buildArgs: " + buildArgs);
             String[] split = Resolver.buildVar(build, buildArgs).split(",|;");
             for (String arg : split) {
-                String[] pair = arg.split("=");
+                String[] pair = arg.split("=", 2);
                 if (pair.length == 2) {
                     buildArgsMap.put(pair[0].trim(), pair[1].trim());
                 } else {


### PR DESCRIPTION
When using the create image command, build args with '=' will not be parsed correctly.

For instance, with these parameters : `test_url=http://example.com?test=something;another_arg=value`
Currently the `test_url` arg will cause this error: ` ERROR: Invalid format for test_url=http://example.com?test=something. Buildargs should be formatted as key=value`. Despite the value being acceptable, there is no way to have the '=' symbol anywhere in a build arg.

This PR fixes this.