### PR TITLE
Use Java 7 versions of GZIPInputStream and GZIPOutputStream

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/action/DockerContainerConsoleAction.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/action/DockerContainerConsoleAction.java
@@ -5,7 +5,7 @@ import com.github.dockerjava.api.command.AttachContainerCmd;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.core.command.AttachContainerResultCallback;
 import com.google.common.base.Charsets;
-import com.jcraft.jzlib.GZIPInputStream;
+import java.util.zip.GZIPInputStream;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.*;
 import hudson.security.ACL;


### PR DESCRIPTION
[JZlib](https://github.com/ymnk/jzlib) has not been updated since 2013. Since then, [`GZIPInputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPInputStream.html) and [`GZIPOutputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPOutputStream.html) have been added to the Java 7 API, so it seems more prudent to use those implementations.