### PR TITLE
Upgrade docker java to 3.2.7 and use http client as transport instead of Jersey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,7 @@
 
     <properties>
         <version.apache.httpclient>4.5.8</version.apache.httpclient>
-        <version.docker.java>3.0.10</version.docker.java>
-        <version.jenkins.docker-commons>1.4.0</version.jenkins.docker-commons>
+        <version.docker.java>3.2.7</version.docker.java>
         <version.jenkins.docker-commons>1.15</version.jenkins.docker-commons>
         <version.glassfish.javax.json>1.1.4</version.glassfish.javax.json>
         <version.jenkins.credentials>2.1.18</version.jenkins.credentials>
@@ -39,13 +38,18 @@
 
     <dependencies>
         <dependency> <!-- Overwrites transitive dependency, otherwise fails with java.lang.ClassNotFoundException: org.apache.http.config.Lookup -->
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${version.apache.httpclient}</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
+            <artifactId>docker-java-core</artifactId>
+            <version>${version.docker.java}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-httpclient5</artifactId>
             <version>${version.docker.java}</version>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -14,7 +15,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
 import hudson.model.Descriptor;
 import hudson.security.ACL;
 import hudson.model.Item;


### PR DESCRIPTION
Upgrade docker java to 3.2.7 and use the http client as transport instead of Jersey

<!-- Please describe your pull request here. -->
The docker build step plugin uses Jersey as the transport to communicate with docker
This causes problems with new version of Jenkins because of conflicts with jersey versions as can be seen at https://github.com/vjuranek/docker-build-step-plugin/issues/64
This PR aims to use new version of docker java and use the http client version 5 as transport instead of Jersey 

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

I built the project, uploaded it to my Jenkins and tried to pull and push from/to private repositories and it works.
