### PR TITLE
Fixes for JENKINS-65498 and JENKINS-67504

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import com.github.dockerjava.api.exception.DockerException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import hudson.Extension;
 import hudson.Launcher;
@@ -229,13 +231,15 @@ public class CreateContainerCommand extends DockerCommand {
 
             String inspectRespSerialized = launcher.getChannel().call(new CreateContainerRemoteCallable(cfgData, descriptor, imageRes, commandRes, hostNameRes, containerNameRes, linksRes, envVarsRes, exposedPortsRes, cpuSharesRes, memoryLimitRes, dnsRes, extraHostsRes, networkModeRes, portBindingsRes, bindMountsRes, alwaysRestart, publishAllPorts, privileged));
             ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             InspectContainerResponse inspectResp = mapper.readValue(inspectRespSerialized, InspectContainerResponse.class);
 
             console.logInfo("created container id " + inspectResp.getId() + " (from image " + imageRes + ")");
             EnvInvisibleAction envAction = new EnvInvisibleAction(inspectResp);
             build.addAction(envAction);
         } catch (Exception e) {
-            console.logError("failed to stop all containers");
+            console.logError("Failed to create container");
             e.printStackTrace();
             throw new IllegalArgumentException(e);
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand.java
@@ -20,6 +20,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Container;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
 /**
@@ -61,6 +63,8 @@ public class StartByImageIdCommand extends DockerCommand {
                     String inspectRespSerialized = launcher.getChannel().call(new StartContainerRemoteCallable(cfgData, descriptor, container.getId()));
                     
                     ObjectMapper mapper = new ObjectMapper();
+                    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+                    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                     InspectContainerResponse inspectResp = mapper.readValue(inspectRespSerialized, InspectContainerResponse.class);
                     
                     console.logInfo("started container id " + container.getId());

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd;
 
 import com.github.dockerjava.api.exception.DockerException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import hudson.Extension;
 import hudson.Launcher;
@@ -76,6 +78,8 @@ public class StartCommand extends DockerCommand {
                 
                 String inspectRespSerialized = launcher.getChannel().call(new StartContainerRemoteCallable(cfgData, descriptor, id));
                 ObjectMapper mapper = new ObjectMapper();
+                mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+                mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 InspectContainerResponse inspectResp = mapper.readValue(inspectRespSerialized, InspectContainerResponse.class);
                 
                 console.logInfo("started container id " + id);

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateContainerRemoteCallable.java
@@ -9,6 +9,7 @@ import org.jenkinsci.plugins.dockerbuildstep.util.LinkUtils;
 import org.jenkinsci.plugins.dockerbuildstep.util.PortBindingParser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
@@ -131,6 +132,7 @@ public class CreateContainerRemoteCallable implements Callable<String, Exception
         InspectContainerResponse inspectResp = client.inspectContainerCmd(resp.getId()).exec();
         
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         String serialized = mapper.writeValueAsString(inspectResp);
         return serialized;
     }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
@@ -6,6 +6,7 @@ import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
@@ -41,6 +42,7 @@ public class StartContainerRemoteCallable implements Callable<String, Exception>
         InspectContainerResponse inspectResp = client.inspectContainerCmd(id).exec();
 
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         String serialized = mapper.writeValueAsString(inspectResp);
         return serialized;
     }


### PR DESCRIPTION
- Fix for [JENKINS-65498](https://issues.jenkins.io/browse/JENKINS-65498) that will prevent an exception from being thrown.
- Fix for [JENKINS-67504](https://issues.jenkins.io/browse/JENKINS-67504) that skips unknown fields instead of throwing an exception.