### PR TITLE
Added Maven job type in Post Build step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <version.jenkins.credentials>2.6.1.1</version.jenkins.credentials>
         <version.maven.release>2.5.3</version.maven.release>
         <version.matrix-project>1.14</version.matrix-project>
+        <version.maven-plugin>2.17</version.maven-plugin>
     </properties>
 
     <dependencies>
@@ -71,6 +72,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>${version.matrix-project}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>maven-plugin</artifactId>
+          <version>${version.maven-plugin}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder.java
@@ -7,6 +7,7 @@ import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
+import hudson.maven.MavenModuleSet;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -37,7 +38,7 @@ public class DockerPostBuilder extends BuildStepDescriptor<Publisher> {
 
     @Override
     public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
-        return FreeStyleProject.class.equals(jobType) || MatrixProject.class.equals(jobType);
+        return FreeStyleProject.class.equals(jobType) || MatrixProject.class.equals(jobType) || MavenModuleSet.class.equals(jobType);
     }
 
     @Override


### PR DESCRIPTION
This change will make the option which stops and removes the Docker container in the Post Build step available in a Maven project job type. Before, it was only available in FreeStyle and Multi-Configuration projects.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
