### PR TITLE
Refresh plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.579</version>
+        <version>4.48</version>
+        <relativePath />
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>docker-build-step</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
-    <url>https://github.com/jenkinsci/docker-build-step-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <developers>
         <developer>
@@ -20,48 +22,44 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/docker-build-step-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/docker-build-step-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/docker-build-step-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>
-        <version.apache.httpclient>4.5.8</version.apache.httpclient>
-        <version.docker.java>3.2.7</version.docker.java>
-        <version.jenkins.docker-commons>1.15</version.jenkins.docker-commons>
-        <version.glassfish.javax.json>1.1.4</version.glassfish.javax.json>
-        <version.jenkins.credentials>2.6.1.1</version.jenkins.credentials>
-        <version.maven.release>2.5.3</version.maven.release>
-        <version.matrix-project>1.17</version.matrix-project>
-        <version.maven-plugin>2.17</version.maven-plugin>
+        <revision>2.9</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.319.3</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <version.jenkins.docker-commons>1.21</version.jenkins.docker-commons>
+        <version.maven-plugin>3.16</version.maven-plugin>
+        <!-- TODO fix violations -->
+        <spotbugs.threshold>High</spotbugs.threshold>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1654.vcb_69d035fa_20</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency> <!-- Overwrites transitive dependency, otherwise fails with java.lang.ClassNotFoundException: org.apache.http.config.Lookup -->
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>5.0</version>
-        </dependency>
         <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-core</artifactId>
-            <version>${version.docker.java}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-transport-httpclient5</artifactId>
-            <version>${version.docker.java}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>${version.glassfish.javax.json}</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>3.2.13-37.vf3411c9828b9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>${version.jenkins.credentials}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -71,21 +69,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>${version.matrix-project}</version>
         </dependency>
         <dependency>
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>maven-plugin</artifactId>
-          <version>${version.maven-plugin}</version>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>maven-plugin</artifactId>
+            <version>${version.maven-plugin}</version>
         </dependency>
     </dependencies>
-
-    <distributionManagement>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/releases</url>
-        </repository>
-    </distributionManagement>
 
     <repositories>
         <repository>
@@ -100,23 +90,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>${version.maven.release}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -13,9 +13,8 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
 
-import com.github.dockerjava.core.DockerClientImpl;
-import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
-import com.github.dockerjava.transport.DockerHttpClient;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand.DockerCommandDescriptor;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -25,10 +24,10 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.DockerCmdExecFactory;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientBuilder;
 
 import com.github.dockerjava.core.LocalDirectorySSLConfig;
 import com.github.dockerjava.core.SSLConfig;
@@ -141,13 +140,10 @@ public class DockerBuilder extends Builder {
 
             DefaultDockerClientConfig config = configBuilder.build();
 
-            DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
-                    .dockerHost(config.getDockerHost())
-                    .sslConfig(config.getSSLConfig())
-                    .maxConnections(100)
+            DockerCmdExecFactory dcef = new NettyDockerCmdExecFactory();
+            return DockerClientBuilder.getInstance(config)
+                    .withDockerCmdExecFactory(dcef)
                     .build();
-
-            return DockerClientImpl.getInstance(config, httpClient);
         }
 
         public FormValidation doTestConnection(@QueryParameter String dockerUrl, @QueryParameter String dockerVersion, @QueryParameter String dockerCertPath) {

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerCredConfig.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import hudson.model.AbstractDescribableImpl;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand.java
@@ -19,7 +19,7 @@ import com.github.dockerjava.api.exception.DockerException;
 /**
  * This command commits changes done in specified container and create new image from it.
  * 
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#create-a-new-image-from-a-containers-changes
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageCommit">Create a new image from a container</a>
  * 
  * @author vjuranek
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * This command creates a new image from specified Dockerfile.
  *
  * @author marcus
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#build-an-image-from-dockerfile-via-stdin
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild">Build an image</a>
  */
 public class CreateImageCommand extends DockerCommand {
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand.java
@@ -84,7 +84,7 @@ public abstract class DockerCommand implements Describable<DockerCommand>, Exten
         return authConfig;
     }
 
-    public static CredentialsMatcher CREDENTIALS_MATCHER = CredentialsMatchers.anyOf(CredentialsMatchers
+    public static final CredentialsMatcher CREDENTIALS_MATCHER = CredentialsMatchers.anyOf(CredentialsMatchers
             .instanceOf(StandardUsernamePasswordCredentials.class));
 
     public abstract void execute(Launcher launcher, @SuppressWarnings("rawtypes") AbstractBuild build, ConsoleLogger console)

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand.java
@@ -21,7 +21,7 @@ import com.github.dockerjava.api.exception.DockerException;
 /**
  * This command kills specified container(s).
  * 
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#kill-a-container
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerKill">Kill a container</a>
  * 
  * @author vjuranek
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand.java
@@ -22,7 +22,7 @@ import com.github.dockerjava.api.exception.DockerException;
 /**
  * This command pulls Docker image from a repository.
  *
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#create-an-image
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageCreate">Create an image</a>
  *
  * @author vjuranek
  *

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand.java
@@ -23,7 +23,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * This command pushes a Docker image on the repository.
  *
  * @author wzheng2310@gmail.com (Wei Zheng)
- * @see https://docs.docker.com/reference/api/docker_remote_api_v1.13/#push-an-image-on-the-registry
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImagePush">Push an image</a>
  */
 public class PushImageCommand extends DockerCommand {
     private final String image;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand.java
@@ -22,7 +22,7 @@ import com.github.dockerjava.api.exception.NotFoundException;
 /**
  * This command removes specified Docker container(s).
  * 
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#remove-a-container
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerDelete">Remove a container</a>
  * 
  * @author vjuranek
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand.java
@@ -19,8 +19,7 @@ import com.github.dockerjava.api.exception.NotFoundException;
 /**
  * This command removes specified Docker image.
  * 
- * @see http 
- *      ://docs.docker.com/reference/api/docker_remote_api_v1.13/#remove-an-image
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageDelete">Remove an image</a>
  * 
  * @author draoullig
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand.java
@@ -21,7 +21,7 @@ import com.github.dockerjava.api.exception.DockerException;
 /**
  * This command restarts specified Docker container(s).
  * 
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#restart-a-container
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerRestart">Restart a container</a>
  * 
  * @author vjuranek
  *

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
@@ -22,7 +22,7 @@ import com.github.dockerjava.api.exception.NotFoundException;
 /**
  * This command saves the specified Docker image.
  * 
- * @see docker save
+ * @see <a href="https://docs.docker.com/engine/reference/commandline/save/">docker save</a>
  * 
  * @author draoullig
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand.java
@@ -29,7 +29,7 @@ import java.util.List;
  * started containers.
  *
  * @author vjuranek
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#start-a-container
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStart">Start a container</a>
  */
 public class StartCommand extends DockerCommand {
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand.java
@@ -21,7 +21,7 @@ import com.github.dockerjava.api.exception.DockerException;
 /**
  * This command stops one or more Docker containers.
  * 
- * @see http://docs.docker.com/reference/api/docker_remote_api_v1.13/#stop-a-container
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStop">Stop a container</a>
  * 
  * @author vjuranek
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand.java
@@ -19,7 +19,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * This command tags the specified Docker image.
  *
  * @author draoullig
- * @see https://docs.docker.com/reference/api/docker_remote_api_v1.19/#tag-an-image-into-a-repository
+ * @see <a href="https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageTag">Tag an image</a>
  */
 public class TagImageCommand extends DockerCommand {
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CommitRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CommitRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
@@ -9,7 +8,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CommitCmd;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -18,7 +16,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class CommitRemoteCallable implements Callable<String, Exception>, Serializable {
+public class CommitRemoteCallable extends MasterToSlaveCallable<String, Exception> {
     
     private static final long serialVersionUID = -8663454265047375486L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateContainerRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.util.BindParser;
@@ -15,11 +14,9 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.RestartPolicy;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -28,7 +25,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class CreateContainerRemoteCallable implements Callable<String, Exception>, Serializable {
+public class CreateContainerRemoteCallable extends MasterToSlaveCallable<String, Exception> {
 
     private static final long serialVersionUID = -4028940605497568422L;
     
@@ -88,7 +85,6 @@ public class CreateContainerRemoteCallable implements Callable<String, Exception
         }
         cfgCmd.withHostName(hostNameRes);
         cfgCmd.withName(containerNameRes);
-        HostConfig hc = new HostConfig();
         cfgCmd.withLinks(LinkUtils.parseLinks(linksRes).getLinks());
         if (envVarsRes != null) {
             cfgCmd.withEnv(envVarsRes);

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/CreateImageRemoteCallable.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Map;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -18,7 +18,6 @@ import hudson.model.BuildListener;
 import hudson.FilePath;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 /**
  * A Callable wrapping the commands necessary to create an image.
@@ -26,7 +25,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class CreateImageRemoteCallable implements Callable<String, Exception>, Serializable {
+public class CreateImageRemoteCallable extends MasterToSlaveCallable<String, Exception> {
 
     private static final long serialVersionUID = -6593420984897195978L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecCreateRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecCreateRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
@@ -9,7 +8,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -18,7 +16,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class ExecCreateRemoteCallable implements Callable<String, Exception>, Serializable {
+public class ExecCreateRemoteCallable extends MasterToSlaveCallable<String, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecStartRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ExecStartRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -12,7 +11,6 @@ import com.github.dockerjava.core.command.ExecStartResultCallback;
 
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -21,7 +19,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class ExecStartRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class ExecStartRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/KillContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/KillContainerRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -17,7 +15,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class KillContainerRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class KillContainerRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ListContainersRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/ListContainersRemoteCallable.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
 import java.util.List;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
@@ -10,7 +10,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -19,7 +18,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class ListContainersRemoteCallable implements Callable<List<Container>, Exception>, Serializable {
+public class ListContainersRemoteCallable extends MasterToSlaveCallable<List<Container>, Exception> {
 
     private static final long serialVersionUID = 8479489609579635741L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PullImageRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -14,7 +13,6 @@ import com.github.dockerjava.core.command.PullImageResultCallback;
 
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -23,7 +21,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class PullImageRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class PullImageRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
     

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/PushImageRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -14,7 +13,6 @@ import com.github.dockerjava.core.command.PushImageResultCallback;
 
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -23,7 +21,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class PushImageRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class PushImageRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveContainerRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -17,7 +15,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class RemoveContainerRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class RemoveContainerRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RemoveImageRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -17,7 +15,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class RemoveImageRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class RemoveImageRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RestartContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/RestartContainerRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -17,7 +15,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class RestartContainerRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class RestartContainerRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 1536648869989705828L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/SaveImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/SaveImageRemoteCallable.java
@@ -3,8 +3,8 @@ package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
@@ -12,7 +12,6 @@ import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -21,7 +20,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class SaveImageRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class SaveImageRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = -6899484703281434847L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StartContainerRemoteCallable.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
@@ -11,7 +10,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -20,7 +18,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class StartContainerRemoteCallable implements Callable<String, Exception>, Serializable {
+public class StartContainerRemoteCallable extends MasterToSlaveCallable<String, Exception> {
 
     private static final long serialVersionUID = 8479489609579635741L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StopContainerRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/StopContainerRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -17,7 +15,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class StopContainerRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class StopContainerRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = -2282315761017156001L;
     

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/TagImageRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/TagImageRemoteCallable.java
@@ -1,14 +1,12 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
-
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 
 import com.github.dockerjava.api.DockerClient;
 
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 /**
  * A Callable wrapping the tag image command.
@@ -16,7 +14,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class TagImageRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class TagImageRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = -6899484703281434847L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/WaitForPortsRemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/remote/WaitForPortsRemoteCallable.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.dockerbuildstep.cmd.remote;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.plugins.dockerbuildstep.DockerBuilder.Config;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -14,7 +14,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.remoting.Callable;
 
 
 /**
@@ -23,7 +22,7 @@ import hudson.remoting.Callable;
  * 
  * @author David Csakvari
  */
-public class WaitForPortsRemoteCallable implements Callable<Void, Exception>, Serializable {
+public class WaitForPortsRemoteCallable extends MasterToSlaveCallable<Void, Exception> {
 
     private static final long serialVersionUID = 8479489609579635741L;
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/DockerConsoleAnnotator.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/DockerConsoleAnnotator.java
@@ -11,7 +11,7 @@ import java.nio.charset.Charset;
  * Console annotator which annotates Docker messages using {@link DockerConsoleNote}. Annotated message has to start
  * with <i>[Docker]</i> prefix.
  * 
- * @see {@link http://javadoc.jenkins-ci.org/hudson/console/LineTransformationOutputStream.html LineTransformationOutputStream} 
+ * @see LineTransformationOutputStream
  * 
  * @author vjuranek
  * 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogMessage.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
  * 
  * As a workaround we borrowed the decoding magic from https://github.com/spotify/docker-client.
  * 
- * @see https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogMessage.java
+ * @see <a href="https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogMessage.java">LogMessage</a>
  */
 public class DockerLogMessage {
     final DockerLogStreamType stream;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamReader.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamReader.java
@@ -18,7 +18,6 @@ package org.jenkinsci.plugins.dockerbuildstep.log.container;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.io.ByteStreams.copy;
-import static com.google.common.io.ByteStreams.nullOutputStream;
 
 import java.io.Closeable;
 import java.io.EOFException;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamReader.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamReader.java
@@ -33,7 +33,7 @@ import com.google.common.io.ByteStreams;
  * 
  * As a workaround we borrowed the decoding magic from https://github.com/spotify/docker-client.
  * 
- * @see https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogReader.java
+ * @see <a href="https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogReader.java">LogReader</a>
  */
 public class DockerLogStreamReader implements Closeable {
     private final InputStream stream;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamType.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/log/container/DockerLogStreamType.java
@@ -21,7 +21,7 @@ package org.jenkinsci.plugins.dockerbuildstep.log.container;
  * 
  * As a workaround we borrowed the decoding magic from https://github.com/spotify/docker-client.
  * 
- * @see https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogMessage.java
+ * @see <a href="https://github.com/spotify/docker-client/blob/master/src/main/java/com/spotify/docker/client/LogMessage.java">LogMessage</a>
  */
 public enum DockerLogStreamType {
     STDIN(0), STDOUT(1), STDERR(2);

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -42,7 +43,7 @@ public class CommandUtils {
 
     public static void logCommandResult(InputStream inputStream,
             ConsoleLogger console, String errMessage) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()));
         String line = null;
         try {
           while((line = in.readLine()) != null) {
@@ -62,7 +63,7 @@ public class CommandUtils {
      */
     public static void logCommandResultStream(InputStream inputStream,
             ConsoleLogger console, String errMessage) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()));
         String line = null;
         try {
           while((line = in.readLine()) != null) {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
     <f:dropdownDescriptorSelector field="dockerCmd" title="Docker command" descriptors="${descriptor.cmdDescriptors}" />

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:section title="Docker Builder">

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/DockerPostBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CommitCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry field="dockerFolder" title="Build context folder">

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/DockerCommand/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateAndStartCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecCreateCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/ExecStartCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/KillCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/PullImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/PushImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveAllCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RestartCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartByImageIdCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StartCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
     <j:set var="descriptor" value="${instance.descriptor}" />

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopAllCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopAllCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopByImageIdCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopByImageIdCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/StopCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/TagImageCommand/config-detail.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
     xmlns:f="/lib/form">
 


### PR DESCRIPTION
Refreshes this plugin for 2022 by updating to the latest build toolchain and dependencies, including the use of the [Docker API plugin](https://plugins.jenkins.io/docker-java-api/) and proper [Remoting Callables](https://www.jenkins.io/doc/developer/security/remoting-callables/). The former is considered a best practice for Jenkins plugins and is the way the [Docker plugin](https://plugins.jenkins.io/docker-plugin/) works as well. For the latter we implemented the [best practices](https://www.jenkins.io/doc/developer/security/remoting-callables/#best-practices) recommended in the documentation. To test this PR I ran a Docker pull command in a Freestyle job both on the controller and agent, before and after this PR. Before this PR I took a thread dump and verified that HttpComponents 5 was being used to communicate with Docker (as expected) and after this PR I took a thread dump and verified that the [Docker API plugin](https://plugins.jenkins.io/docker-java-api/) was using Netty to communicate with Docker (as expected).

CC @vjuranek