### PR TITLE
Modernize plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.4</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useContainerAgent: false, configurations: [
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.48</version>
+        <version>4.73</version>
         <relativePath />
     </parent>
 
@@ -25,16 +25,14 @@
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
-        <tag>docker-build-step-2.9</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>
         <revision>2.10</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <version.jenkins.docker-commons>1.21</version.jenkins.docker-commons>
-        <version.maven-plugin>3.16</version.maven-plugin>
         <!-- TODO fix violations -->
         <spotbugs.threshold>High</spotbugs.threshold>
     </properties>
@@ -43,8 +41,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2465.va_e76ed7b_3061</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -55,7 +53,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-java-api</artifactId>
-            <version>3.2.13-37.vf3411c9828b9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -64,7 +61,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>${version.jenkins.docker-commons}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -73,7 +69,12 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>${version.maven-plugin}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -13,8 +14,8 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
 
-import com.github.dockerjava.api.command.DockerCmdExecFactory;
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand;
 import org.jenkinsci.plugins.dockerbuildstep.cmd.DockerCommand.DockerCommandDescriptor;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
@@ -140,9 +141,11 @@ public class DockerBuilder extends Builder {
 
             DefaultDockerClientConfig config = configBuilder.build();
 
-            DockerCmdExecFactory dcef = new NettyDockerCmdExecFactory();
+            DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
+                    .dockerHost(URI.create(dockerUrl))
+                    .build();
             return DockerClientBuilder.getInstance(config)
-                    .withDockerCmdExecFactory(dcef)
+                    .withDockerHttpClient(httpClient)
                     .build();
         }
 


### PR DESCRIPTION
Updates to latest dependency chain including the latest Docker Client (backed by Apache HttpClient rather than Netty). Tested interactively by running a Docker pull command in a Jenkins job.