### PR TITLE
Replace EOL spinner.gif

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/action/DockerContainerConsoleAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/action/DockerContainerConsoleAction/index.jelly
@@ -54,7 +54,7 @@ Displays the Docker container output, based on Jenkins console.jelly
         <j:when test="${it.isLogUpdated()}">
           <pre id="out" class="console-output"/>
           <div id="spinner">
-            <img src="${imagesURL}/spinner.gif" alt="" /> 
+            <l:progressAnimation/>
           </div>
          <t:progressiveText href="progressiveHtml" idref="out" spinner="spinner" startOffset="${offset}" />
         </j:when>


### PR DESCRIPTION
The change proposed replaces the EOL spinner.gif with the drop-in Jelly tag replacement.