### PR TITLE
Fix SECURITY-3200: CSRF protection, permission checks, and supply chain hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ work/
 .DS_Store
 .idea/
 *.iml
+.claude/

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -156,10 +156,7 @@ public class DockerBuilder extends Builder {
             Jenkins.get().checkPermission(Jenkins.MANAGE);
             LOGGER.fine(String.format("Trying to get client for %s and version %s and cert path %s", dockerUrl, dockerVersion, dockerCertPath));
             try {
-                this.dockerUrl = dockerUrl;
-                this.dockerVersion = dockerVersion;
-                this.dockerCertPath = dockerCertPath;
-                DockerClient dockerClient = getDockerClient(null, null);
+                DockerClient dockerClient = createDockerClient(dockerUrl, dockerVersion, dockerCertPath, null);
                 dockerClient.pingCmd().exec();
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, e.getMessage(), e);

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/DockerBuilder.java
@@ -23,6 +23,7 @@ import org.jenkinsci.plugins.dockerbuildstep.util.Resolver;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
@@ -41,6 +42,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import jenkins.model.Jenkins;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
@@ -149,7 +151,9 @@ public class DockerBuilder extends Builder {
                     .build();
         }
 
+        @RequirePOST
         public FormValidation doTestConnection(@QueryParameter String dockerUrl, @QueryParameter String dockerVersion, @QueryParameter String dockerCertPath) {
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
             LOGGER.fine(String.format("Trying to get client for %s and version %s and cert path %s", dockerUrl, dockerVersion, dockerCertPath));
             try {
                 this.dockerUrl = dockerUrl;

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -20,6 +20,7 @@ import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.jenkinsci.plugins.dockerbuildstep.util.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * This command creates new container from specified image.
@@ -252,6 +253,7 @@ public class CreateContainerCommand extends DockerCommand {
             return "Create container";
         }
 
+        @RequirePOST
         public FormValidation doTestPortBindings(@QueryParameter String portBindings) {
             try {
                 PortBindingParser.parse(portBindings);
@@ -261,6 +263,7 @@ public class CreateContainerCommand extends DockerCommand {
             return FormValidation.ok("OK");
         }
 
+        @RequirePOST
         public FormValidation doTestBindMounts(@QueryParameter String bindMounts) {
             try {
                 BindParser.parse(bindMounts);
@@ -270,6 +273,7 @@ public class CreateContainerCommand extends DockerCommand {
             return FormValidation.ok("OK");
         }
 
+        @RequirePOST
         public FormValidation doTestEnvVars(@QueryParameter String envVars) {
             try {
                 envVars.split("\\r?\\n");

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -275,10 +275,13 @@ public class CreateContainerCommand extends DockerCommand {
 
         @RequirePOST
         public FormValidation doTestEnvVars(@QueryParameter String envVars) {
-            try {
-                envVars.split("\\r?\\n");
-            } catch (IllegalArgumentException e) {
-                return FormValidation.error(e.getMessage());
+            if (envVars == null || envVars.trim().isEmpty()) {
+                return FormValidation.ok("OK");
+            }
+            for (String line : envVars.split("\\r?\\n")) {
+                if (!line.trim().isEmpty() && !line.contains("=")) {
+                    return FormValidation.error("Invalid env var format (expected KEY=VALUE): " + line);
+                }
             }
             return FormValidation.ok("OK");
         }

--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtils.java
@@ -8,14 +8,16 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import net.sf.json.JSONObject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.exception.DockerException;
 
 /**
@@ -24,6 +26,10 @@ import com.github.dockerjava.api.exception.DockerException;
  * @author wzheng2310@gmail.com (Wei Zheng)
  */
 public class CommandUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(CommandUtils.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     public static String imageFullNameFrom(String registry, String repoAndImg, String tag) {
         if (StringUtils.isNotBlank(registry) || StringUtils.isNotBlank(tag)) {
             StringBuilder sb = new StringBuilder();
@@ -48,9 +54,13 @@ public class CommandUtils {
         try {
           while((line = in.readLine()) != null) {
             console.logInfo(line);
-            JSONObject jsonResponse = JSONObject.fromObject(line);
-            if (jsonResponse.containsKey("error") || jsonResponse.containsKey("errorDetail")) {
-              throw new DockerException(line, 200);
+            try {
+              JsonNode json = MAPPER.readTree(line);
+              if (json.has("error") || json.has("errorDetail")) {
+                throw new DockerException(line, 200);
+              }
+            } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+              LOGGER.log(Level.FINE, "Non-JSON line from Docker stream, skipping error check: {0}", line);
             }
           }
         } catch (IOException e) {

--- a/src/test/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/dockerbuildstep/util/CommandUtilsTest.java
@@ -2,7 +2,16 @@ package org.jenkinsci.plugins.dockerbuildstep.util;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import hudson.model.StreamBuildListener;
+import org.jenkinsci.plugins.dockerbuildstep.log.ConsoleLogger;
 import org.junit.Test;
+
+import com.github.dockerjava.api.exception.DockerException;
 
 /**
  * Class that tests CommandUtils
@@ -45,7 +54,7 @@ public class CommandUtilsTest {
     @Test
     public void testSizeInBytes() {
     	String[] input = {
-    			"64", "128b", "256k", "512m", "1g", "666a", "-9mb" 
+    			"64", "128b", "256k", "512m", "1g", "666a", "-9mb"
     	};
     	long[] output = {
     			64, 128, 262144, 536870912, 1073741824, -1, -1
@@ -54,5 +63,107 @@ public class CommandUtilsTest {
         for (int i = 0; i < input.length; i++ ) {
             assertEquals(output[i], CommandUtils.sizeInBytes(input[i]));
         }
+    }
+
+    // --- logCommandResult tests ---
+
+    private ConsoleLogger createConsoleLogger() {
+        return new ConsoleLogger(new StreamBuildListener(new ByteArrayOutputStream()));
+    }
+
+    private ByteArrayInputStream toInputStream(String... lines) {
+        return new ByteArrayInputStream(String.join("\n", lines).getBytes(Charset.defaultCharset()));
+    }
+
+    @Test
+    public void logCommandResult_normalStatus_noException() {
+        String input = "{\"status\":\"Pulling from library/ubuntu\",\"id\":\"latest\"}";
+        CommandUtils.logCommandResult(toInputStream(input), createConsoleLogger(), "pull failed");
+        // no exception expected
+    }
+
+    @Test
+    public void logCommandResult_multipleNormalLines_noException() {
+        CommandUtils.logCommandResult(
+            toInputStream(
+                "{\"status\":\"Pulling from library/ubuntu\"}",
+                "{\"status\":\"Pulling fs layer\"}",
+                "{\"status\":\"Download complete\"}"
+            ),
+            createConsoleLogger(),
+            "pull failed"
+        );
+    }
+
+    @Test(expected = DockerException.class)
+    public void logCommandResult_errorKey_throwsDockerException() {
+        String input = "{\"error\":\"manifest unknown\"}";
+        CommandUtils.logCommandResult(toInputStream(input), createConsoleLogger(), "pull failed");
+    }
+
+    @Test(expected = DockerException.class)
+    public void logCommandResult_errorDetailKey_throwsDockerException() {
+        String input = "{\"errorDetail\":{\"message\":\"not found\"}}";
+        CommandUtils.logCommandResult(toInputStream(input), createConsoleLogger(), "pull failed");
+    }
+
+    @Test
+    public void logCommandResult_nonJsonLine_noException() {
+        CommandUtils.logCommandResult(
+            toInputStream("Some plain text that is not JSON"),
+            createConsoleLogger(),
+            "pull failed"
+        );
+    }
+
+    @Test
+    public void logCommandResult_mixedJsonAndNonJson_noException() {
+        CommandUtils.logCommandResult(
+            toInputStream(
+                "Header line",
+                "{\"status\":\"Pulling from library/ubuntu\"}",
+                "Progress: 100%"
+            ),
+            createConsoleLogger(),
+            "pull failed"
+        );
+    }
+
+    @Test
+    public void logCommandResult_emptyStream_noException() {
+        CommandUtils.logCommandResult(
+            toInputStream(""),
+            createConsoleLogger(),
+            "pull failed"
+        );
+    }
+
+    @Test
+    public void logCommandResult_errorAfterNormalLines_throwsDockerException() {
+        try {
+            CommandUtils.logCommandResult(
+                toInputStream(
+                    "{\"status\":\"Pulling from library/ubuntu\"}",
+                    "{\"status\":\"Pulling fs layer\"}",
+                    "{\"error\":\"unauthorized\"}"
+                ),
+                createConsoleLogger(),
+                "pull failed"
+            );
+            fail("Should have thrown DockerException");
+        } catch (DockerException e) {
+            assertTrue(e.getMessage().contains("unauthorized"));
+        }
+    }
+
+    @Test(expected = DockerException.class)
+    public void logCommandResult_ioException_throwsDockerException() throws Exception {
+        InputStream broken = new InputStream() {
+            @Override
+            public int read() throws java.io.IOException {
+                throw new java.io.IOException("simulated IO failure");
+            }
+        };
+        CommandUtils.logCommandResult(broken, createConsoleLogger(), "fallback error");
     }
 }


### PR DESCRIPTION
## Summary

Fixes [SECURITY-3200](https://www.jenkins.io/security/advisory/2024-03-06/#SECURITY-3200) / [CVE-2024-2215](https://nvd.nist.gov/vuln/detail/cve-2024-2215) and eliminates an unsafe dependency on the unmaintained `net.sf.json` (json-lib) library.

### SECURITY-3200 — CSRF protection and permission checks

- Add `@RequirePOST` to all form validation web methods to prevent CSRF attacks
- Add `Jenkins.MANAGE` permission check to `doTestConnection()` which connects to arbitrary Docker server URLs
- Fix `doTestConnection()` no longer mutates descriptor state during connection testing
- Fix `doTestEnvVars()` validation was a no-op (`String.split()` never throws `IllegalArgumentException`), now validates `KEY=VALUE` format

| Method | Fix |
|--------|-----|
| `DockerBuilder.DescriptorImpl.doTestConnection()` | `@RequirePOST` + `Jenkins.MANAGE` permission + no more state mutation |
| `CreateContainerCommand.DescriptorImpl.doTestPortBindings()` | `@RequirePOST` |
| `CreateContainerCommand.DescriptorImpl.doTestBindMounts()` | `@RequirePOST` |
| `CreateContainerCommand.DescriptorImpl.doTestEnvVars()` | `@RequirePOST` + real validation |

`DockerCredConfig.DescriptorImpl.doFillCredentialsIdItems()` was already correctly protected with `@AncestorInPath` + `Item.CONFIGURE` check.

### Supply chain hardening — Replace json-lib with Jackson

`net.sf.json.JSONObject.fromObject()` (json-lib) is unmaintained and vulnerable to DoS via crafted JSON input (CVE-2022-45685 / CVE-2022-45687 class). Additionally, it crashes on non-JSON lines from Docker API streams instead of handling them gracefully.

- Replace `JSONObject.fromObject()` with `ObjectMapper.readTree()` + `JsonNode.has()`
- Non-JSON lines are now gracefully skipped (FINE-level log) instead of throwing `JSONException`
- Jackson (`com.fasterxml.jackson`) is already on the classpath via `jackson2-api` plugin
- Add 8 unit tests for `logCommandResult()` covering: normal output, error/errorDetail detection, non-JSON tolerance, mixed content, empty stream, and IO error wrapping

## Test plan

- [x] Build passes: `mvn compile`
- [x] All 74 tests pass: `mvn test`
- [ ] Verify `doTestConnection` requires POST and `Jenkins.MANAGE` permission
- [ ] Verify `doTestPortBindings`, `doTestBindMounts`, `doTestEnvVars` require POST
- [ ] Verify `doTestEnvVars` rejects invalid input like `FOOBAR` (missing `=`)
- [ ] Verify normal plugin configuration workflow still works end-to-end
- [ ] Verify Docker pull/push operations still correctly detect errors via `logCommandResult`

🤖 Generated with [Claude Code](https://claude.com/claude-code)